### PR TITLE
Restructured the repo to allow multiple issuers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@ _Do not delete_
 
 ## What is this for?
 
-When validating an authentication token (JWT) from a valid Identity Provider (IdP), the service (e.g. a Stash Data Service) must
-first fetch the public keys from the JSON Web Key Set (JWKS).
+When validating an authentication token (JWT) from a valid Identity Provider (IdP), the service (e.g. a Stash Data Service) must first fetch the public keys from the JSON Web Key Set (JWKS).
 
-In testing this is a bit tricky as we generate our own tokens inside the test suite.
-So, to validate the URL of this repo is set as the JWKS url.
+In testing this is a bit tricky as we generate our own tokens inside the test suite.  So, to validate the URL of this repo is set as the JWKS url.
 
 ## Files
 
-Only one file is stored in this repo and that is `.well-known/jwks.json`.
+This repository exposes two JWKS issuers known as issuer-0 & issuer-1.
+
+`jwks.json` files are publicly accessible at `https://cipherstash.github.io/test-jwks/issuer-0/.well-known./jwks.json` and `https://cipherstash.github.io/test-jwks/issuer-1/.well-known./jwks.json` .
+
+The aforementioned files are used as JSON Web Key Sets in testing the `data-service` in the `platform` repo.
+
+The corresponding key ID and `.pem` files are managed in the `platform` repo. Keep in mind that the `.pem` files and key IDs are cryptographically related to the `jwks.json` files, so must be generated together.

--- a/issuer-0/.well-known/jwks.json
+++ b/issuer-0/.well-known/jwks.json
@@ -1,0 +1,13 @@
+{
+  "keys": [
+    {
+      "alg": "RS256",
+      "e": "AQAB",
+      "kid": "ov_3-JdGUaX90ppyGtfiNC5BkZPggknU-aRhYXuHLKc",
+      "kty": "RSA",
+      "n": "pVSaiyeQ_avyiBrs8kHPnAy-lfSndBahhREpZfcaqao_LEnO1wNnlp-RSy76mP1a57TVdsGcSIHA0cNagKkI5DzTWC1P7erO3FdKuBbLZS6vyTmGYZmDd_Zy1xERUAPeZi4y7LUFNDkL7zm5j0bCUq1VpNltbypLnMvguQpRn7DcGgsRgokQwQ53-dC4T27l2WwSYgsdv8gNlLT9coeHlOodeZq_hvJrSIJ-bwbT6QlH_cZJEmnBCx6h2_4y2_EISuSl38NaZ592bJYW_Crw66beL0IE2tKk5iuXOaRPqqdduKGC8Q0Gv9d0-BtMFwB11XBtj5FOnh0vDlAe95woqQ",
+      "use": "sig"
+    }
+  ]
+}
+

--- a/issuer-1/.well-known/jwks.json
+++ b/issuer-1/.well-known/jwks.json
@@ -1,0 +1,12 @@
+{
+  "keys": [
+    {
+      "alg": "RS256",
+      "e": "AQAB",
+      "kid": "jNzDc0y89dCtFKR785xIGEBzCvLfqlINs7fwguqTfkE",
+      "kty": "RSA",
+      "n": "xQ0bt9Ci56efdcZizX1dPKI7zIHiUpw5hJH_VGf-c3VgugfobXzsNpG2_oTci6v3oGvhtDLtRhKH2btKVchfN42__6KDH7zcWV--4cqzT3rSWFGydupspuaktydagpmXGryKH5UAPzw2dayKUrbEvD2ePiw7HiolrCEbLafeHDACzMyx2c8x4UDXUvmWUojLXwqmnnEhwztYkL0U59JUOsVYn5R5iX2ZF35USTHawU_VfpMFaTDf0JlpnzViOa2poSvkSxtoAUaQ2lp-ZbR9EetymEK0j2CefDa9YiZ-dbzpM2pe0gDt25oHXuLCanKFxVltpL6t2UlxTWa9N_zV9w",
+      "use": "sig"
+    }
+  ]
+}


### PR DESCRIPTION
Restructured the repo to allow multiple issuers
    
This will be used for testing with an invalid issuer in platform/data-service.
    
The top-level directory now contains a directory for each issuer.
`issuer-0` is the pre-existing issuer. `issuer-1` is an alternative
issuer for testing against.
    
In order to not break the platform build (until corresponding changes
have been merged there), issuer-0 is duplicated at its previous location
of ~/.well-known. The duplication will be removed in a subsequent PR.